### PR TITLE
fix patching objects which contain none of their original keys (#5)

### DIFF
--- a/src/patch.ts
+++ b/src/patch.ts
@@ -253,29 +253,18 @@ function patchObject(
 
 		const propertyValue = value[key];
 
-		if (newlinesInsideValue) {
-			patched +=
-				`,${indentation}` +
-				stringifyProperty(
-					key,
-					propertyValue,
-					quote,
-					indentation,
-					indentString,
-					true
-				);
-		} else {
-			patched +=
-				`, ` +
-				stringifyProperty(
-					key,
-					propertyValue,
-					quote,
-					indentation,
-					indentString,
-					false
-				);
-		}
+		patched +=
+			(started ? ',' : intro) +
+			(newlinesInsideValue ? indentation : ' ') +
+			stringifyProperty(
+				key,
+				propertyValue,
+				quote,
+				indentation,
+				indentString,
+				newlinesInsideValue
+			);
+		started = true;
 	});
 
 	patched += str.slice(c, node.end);

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -254,8 +254,7 @@ function patchObject(
 		const propertyValue = value[key];
 
 		patched +=
-			(started ? ',' : intro) +
-			(newlinesInsideValue ? indentation : ' ') +
+			(started ? ',' + (newlinesInsideValue ? indentation : ' ') : intro) +
 			stringifyProperty(
 				key,
 				propertyValue,

--- a/test/test.ts
+++ b/test/test.ts
@@ -599,6 +599,22 @@ multi-line string',
 						y: 0
 					}
 				}`
+			},
+
+			{
+				input: `{foo:'foo'}`,
+				value: { bar: 'bar' },
+				output: `{bar: 'bar'}`
+			},
+
+			{
+				input: `{
+					foo: 'foo'
+				}`,
+				value: { bar: 'bar' },
+				output: `{
+					bar: 'bar'
+				}`
 			}
 		];
 


### PR DESCRIPTION
No tests yet because this is still a WIP. There's some whitespace fiddliness that I haven't worked out yet but this should at least now output valid json5.