### PR TITLE
bundle locate-character dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "golden-fleece",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -313,7 +313,8 @@
     "locate-character": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-2.0.3.tgz",
-      "integrity": "sha512-hUwasl2ZUHxwHz6nRDNxbaErWEqEls2g0MLNQi5xOYd56OUChmtILVbJqyg3GKREEgp8eKbedM4Xvp2Ijqa4qQ=="
+      "integrity": "sha512-hUwasl2ZUHxwHz6nRDNxbaErWEqEls2g0MLNQi5xOYd56OUChmtILVbJqyg3GKREEgp8eKbedM4Xvp2Ijqa4qQ==",
+      "dev": true
     },
     "lodash": {
       "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "degit": "^2.0.1",
     "glob": "^7.1.2",
     "json5": "^0.5.1",
+    "locate-character": "^2.0.3",
     "mocha": "^3.5.0",
     "right-pad": "^1.0.1",
     "rollup": "^0.49.2",
@@ -36,8 +37,5 @@
     "fetch_tests": "degit json5/json5-tests test/json5-tests",
     "test": "mocha --opts mocha.opts",
     "prepublishOnly": "npm test && npm run build"
-  },
-  "dependencies": {
-    "locate-character": "^2.0.3"
   }
 }


### PR DESCRIPTION
There's no good reason afaict to have locate-character be a dependency rather than a devdependency and bundle it.